### PR TITLE
Correct capitalization of PyYAML

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-PyYaml
+PyYAML


### PR DESCRIPTION
pip is case-sensitive, so the name of the dependency must exactly match the capitalization of the required package. If this is not the package you meant, please update as needed:
https://pypi.org/project/PyYAML/